### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ iOS/tvOS only React Native wrapper for the AVRoutePickerView (selector for AirPl
 ```tsx
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { ExpoAvRoutePickerView } from 'expo-av-route-picker-view';
+import { ExpoAvRoutePickerView } from '@douglowder/expo-av-route-picker-view';
 
 export default function App() {
   return (


### PR DESCRIPTION
Looks like the README.md was referring to a library that doesn't exist. I've added the correct namespace.